### PR TITLE
Add back community styles

### DIFF
--- a/website/docs/vale/styles.mdx
+++ b/website/docs/vale/styles.mdx
@@ -160,4 +160,4 @@ as described in the table below.
 ## Third-party styles
 
 Vale has a growing selection of pre-made styles available for download from its
-[style library](https://github.com/errata-ai/styles).
+[style library](https://github.com/errata-ai/styles), and community-maintained styles you can find by sreaching for the "[vale-linter-style](https://github.com/topics/vale-linter-style)" tag on GitHub.


### PR DESCRIPTION
The new docs seemed to remove the reference to the community styles many have worked on, and people use, so added a link back.