### PR TITLE
Add exceptions in the example definition

### DIFF
--- a/website/docs/common/points/capitalization.md
+++ b/website/docs/common/points/capitalization.md
@@ -8,6 +8,9 @@ scope: heading
 # $title, $sentence, $lower, $upper, or a pattern.
 match: $title
 style: AP # AP or Chicago; only applies when match is set to $title.
+exceptions:
+  - ABC
+  - add
 ```
 
 #### Key summary


### PR DESCRIPTION
Showcase how to declare/use the `exceptions` attribute in a `capitalization` rule.