### PR TITLE
Fix a couple of errors in cli.mdx

### DIFF
--- a/website/docs/vale/cli.mdx
+++ b/website/docs/vale/cli.mdx
@@ -38,7 +38,7 @@ as shown below):
 :::
 
 
-If you'd like to follow along locally, download or clone sample repository and
+If you'd like to follow along locally, download or clone the sample repository and
 copy the terminal session below:
 
 ```bash
@@ -105,7 +105,7 @@ styles](https://github.com/errata-ai/styles).
 
 ### Vocab
 
-The [`Vocab` directory](/vale/vocab) is a special directory design to
+The [`Vocab` directory](/vale/vocab) is a special directory designed to
 supplement your styles. Each of its child directories&mdash;in this case,
 `Blog` and `Marketing`&mdash;contain two files: `accept.txt` and `reject.txt`.
 
@@ -231,7 +231,7 @@ alerts.
 $ vale --output=JSON directory
 ```
 
-In addition to the 3 provided output styles, Vale also supports (as of `v2.6`)
+In addition to the three provided output styles, Vale also supports (as of `v2.6`)
 custom output styles powered by Go's
 [`text/template`](https://golang.org/pkg/text/template/) package.
 


### PR DESCRIPTION
Fixed a typo, a possible style issue ("three" instead of "3"), and a missing word.